### PR TITLE
Point to kernel in /lib/modules/XXX/build

### DIFF
--- a/beaglelogic-kernel-driver/Makefile
+++ b/beaglelogic-kernel-driver/Makefile
@@ -2,7 +2,7 @@
 # This file is a part of the BeagleLogic project
 
 # Path to kernel sources relative to current directory
-KSRC = $(PWD)/../../BeagleBone/kernel/kernel
+KSRC = /lib/modules/$(shell uname -r)/build
 
 # Host name of BBB (like root@192.168.7.2)
 BBHOST = root@192.168.7.2


### PR DESCRIPTION
I like the method https://github.com/deepakkarki/pruspeak/ uses to fetch the kernel sources.
