### PR TITLE
bone_pwm_P9_31-00A0.dts: add legacy overlay and update Makefile

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,10 +14,14 @@ clean:
 	@make -C $(KSRC) M=$(PWD) ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- clean
 
 # Compile and install device tree
-overlay: beaglelogic-00A0.dtbo
+overlay: beaglelogic-00A0.dtbo bone_pwm_P9_31-00A0.dtbo
 
 beaglelogic-00A0.dtbo: beaglelogic-00A0.dts
 	dtc -O dtb -o beaglelogic-00A0.dtbo -b 0 -@ beaglelogic-00A0.dts
 
+bone_pwm_P9_31-00A0.dtbo: bone_pwm_P9_31-00A0.dts
+	dtc -O dtb -o bone_pwm_P9_31-00A0.dtbo -b 0 -@ beaglelogic-00A0.dts
+
 deploy_overlay:
 	cp -v beaglelogic-00A0.dtbo /lib/firmware
+	cp -v bone_pwm_P9_31-00A0.dtbo /lib/firmware

--- a/kernel/bone_pwm_P9_31-00A0.dts
+++ b/kernel/bone_pwm_P9_31-00A0.dts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2013 CircuitCo
+ * Copyright (C) 2013 Texas Instruments
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+	/* identification */
+	part-number = "bone_pwm_P9_31";
+	version = "00A0";
+
+	/* state the resources this cape uses */
+	exclusive-use =
+		/* the pin header uses */
+		"P9.31",		/* pwm: ehrpwm0A */
+		/* the hardware IP uses */
+		"ehrpwm0A";
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			pwm_P9_31: pinmux_pwm_P9_31_pins {
+				pinctrl-single,pins = <0x190  0x1>; /* P9_31 (ZCZ ball A13) | MODE 1 */
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&ocp>;
+		__overlay__ {
+			pwm_test_P9_31 {
+				compatible	= "pwm_test";
+				pwms 		= <&ehrpwm0 0 500000 1>;
+				pwm-names 	= "PWM_P9_31";
+			    pinctrl-names	= "default";
+			    pinctrl-0	= <&pwm_P9_31>;
+				enabled		= <1>;
+				duty		= <0>;
+				status 		= "okay";
+			};
+		};
+	};
+};
+


### PR DESCRIPTION
Note this does not yet produce a usable pwm_test_P9_31 device with files to set duty cycle and period.  Since you're a lot closer to this than I am, maybe you can make it work.

