### PR TITLE
fix lock issue in continuous capture mode with dma transmission

### DIFF
--- a/kernel/beaglelogic.c
+++ b/kernel/beaglelogic.c
@@ -624,6 +624,8 @@ ssize_t beaglelogic_f_read (struct file *filp, char __user *buf,
 perform_copy:
 	count = min(reader->remaining, sz);
 
+	dma_sync_single_for_cpu(dev, reader->buf->phys_addr, reader->buf->size, DMA_FROM_DEVICE);   // sync for cpu to access the buffer
+
 	if (copy_to_user(buf, reader->buf->buf + reader->pos, count))
 		return -EFAULT;
 
@@ -644,6 +646,8 @@ perform_copy:
 		reader->pos = 0;
 		reader->remaining = reader->buf->size;
 	}
+
+	dma_sync_single_for_device(dev, reader->buf->phys_addr, reader->buf->size, DMA_FROM_DEVICE);    // sync for device to access the buffer
 
 	return count;
 }


### PR DESCRIPTION
#### Issue:

When capturing data in the continuous mode by using a simple python script with `os.read()`, the code will work fine for a random period of time, and then the whole beaglebone is frozen and it has to be rebooted by unplugging the power cable.

#### Hypotheses and fix:

One hypothesis is that when doing the DMA transmission, both the CPU and the device are trying to access the same memory at the same time which causes this issue:

The fix is adding two lines in the `f_read()` function as below:
`dma_sync_single_for_cpu(dev, reader->buf->phys_addr, reader->buf->size, DMA_FROM_DEVICE);   // sync for cpu to access the buffer`
`dma_sync_single_for_device(dev, reader->buf->phys_addr, reader->buf->size, DMA_FROM_DEVICE);    // sync for device to access the buffer`
which will temporarily give CPU the access for the memory before reading data, and return the access to the device after reading data.

#### Other comments:

It is not very clear how both the CPU and the device trying to access the memory will lead to this issue, but after the fix, the issue described above is gone. 
Also, in the continuous mode, it is not necessary to have the interrupt service routine to ummap the buffer every time, which I guess can be moved to the end before the device is closed.

